### PR TITLE
Preact breaks on BrowserRouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "highland": "^2.11.1",
     "level": "^2.0.1",
     "prettier": "^1.8.2",
-    "react-snap": "^1.1.1",
+    "react-snap": "1.4.0",
     "readdirp": "^2.1.0",
     "s3-sync-aws": "^1.1.1",
     "sw-precache": "^5.2.0",
@@ -43,7 +43,6 @@
     "inlineCss": true,
     "asyncScriptTags": false,
     "removeStyleTags": false,
-    "include": ["/shell.html"],
-    "sourceMaps": true
+    "include": ["/shell.html"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build-react": "react-scripts build",
     "build-preact": "node scripts/build-preact.js",
     "build":
-      "yarn run build-react && react-snap && yarn run generate-sw && yarn run generate-appcache",
+      "yarn run build-preact && react-snap && yarn run generate-sw && yarn run generate-appcache",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "generate-sw":
@@ -43,6 +43,7 @@
     "inlineCss": true,
     "asyncScriptTags": false,
     "removeStyleTags": false,
-    "include": ["/shell.html"]
+    "include": ["/shell.html"],
+    "sourceMaps": true
   }
 }

--- a/scripts/build-preact.js
+++ b/scripts/build-preact.js
@@ -1,8 +1,8 @@
 process.env.NODE_ENV = "production";
 
-const config = require("react-scripts/config/webpack.config.prod");
+const config = require("react-scripts-cssmodules/config/webpack.config.prod");
 
 config.resolve.alias["react"] = "preact-compat";
 config.resolve.alias["react-dom"] = "preact-compat";
 
-require("react-scripts/scripts/build");
+require("react-scripts-cssmodules/scripts/build");

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { hydrate, render } from "react-dom";
-// import { render } from 'react-dom';
+// import { hydrate, render } from "react-dom";
+import { render } from "react-dom";
 import App from "./App";
 import "./index.css";
 import registerServiceWorker, { unregister } from "./registerServiceWorker";
@@ -19,14 +19,14 @@ const AppWithRouter = (
 
 const rootElement = document.getElementById("root");
 
-if (rootElement.hasChildNodes()) {
-  loadComponents().then(() => {
-    hydrate(AppWithRouter, rootElement);
-  });
-} else {
-  render(AppWithRouter, rootElement);
-}
+// if (rootElement.hasChildNodes()) {
+//   loadComponents().then(() => {
+//     hydrate(AppWithRouter, rootElement);
+//   });
+// } else {
+//   render(AppWithRouter, rootElement);
+// }
 
-// render(<App />, rootElement);
+render(<AppWithRouter />, rootElement);
 // registerServiceWorker();
 unregister();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,10 +1476,6 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.11.x, commander@~2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-
 commander@2.12.x, commander@~2.12.1:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
@@ -1820,7 +1816,7 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.4.1, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8:
+debug@2.6.9, debug@^2.2.0, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -3185,7 +3181,7 @@ html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
-html-minifier@^3.2.3:
+html-minifier@^3.2.3, html-minifier@^3.5.5:
   version "3.5.7"
   resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.7.tgz#511e69bb5a8e7677d1012ebe03819aa02ca06208"
   dependencies:
@@ -3197,19 +3193,6 @@ html-minifier@^3.2.3:
     param-case "2.1.x"
     relateurl "0.2.x"
     uglify-js "3.2.x"
-
-html-minifier@^3.5.5:
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.6.tgz#7e4e661a09999599c7d8e8a2b8d7fb7430bb5c3e"
-  dependencies:
-    camel-case "3.0.x"
-    clean-css "4.1.x"
-    commander "2.11.x"
-    he "1.1.x"
-    ncname "1.0.x"
-    param-case "2.1.x"
-    relateurl "0.2.x"
-    uglify-js "3.1.x"
 
 html-webpack-plugin@2.29.0:
   version "2.29.0"
@@ -3285,11 +3268,11 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
 https-proxy-agent@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.0.tgz#1391bee7fd66aeabc0df2a1fa90f58954f43e443"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz#a7ce4382a1ba8266ee848578778122d491260fd9"
   dependencies:
     agent-base "^4.1.0"
-    debug "^2.4.1"
+    debug "^3.1.0"
 
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
@@ -6766,13 +6749,6 @@ typedarray@^0.0.6:
 ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
-
-uglify-js@3.1.x:
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.1.10.tgz#c4a5f9b5c6276b40cb971c1d97c9eeb26af9509c"
-  dependencies:
-    commander "~2.11.0"
-    source-map "~0.6.1"
 
 uglify-js@3.2.x, uglify-js@^3.0.13:
   version "3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5691,9 +5691,9 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^0.2.2"
 
-react-snap@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-snap/-/react-snap-1.1.1.tgz#8957beb872d3da24422a7942221bd66ddd349bd8"
+react-snap@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-snap/-/react-snap-1.4.0.tgz#eee141f54b33d0317c1141dbe3d5454d98969a14"
   dependencies:
     clean-css "^4.1.9"
     express "^4.16.1"
@@ -5704,7 +5704,7 @@ react-snap@^1.1.1:
     mkdirp "^0.5.1"
     puppeteer "^0.11.0"
     serve-static "^1.13.1"
-    sourcemapped-stacktrace-node "^2.0.4"
+    sourcemapped-stacktrace-node "^2.1.5"
 
 react@^16.1.1:
   version "16.1.1"
@@ -6325,9 +6325,9 @@ source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
-sourcemapped-stacktrace-node@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/sourcemapped-stacktrace-node/-/sourcemapped-stacktrace-node-2.0.4.tgz#63377c3459823b52662850638750ac8cb107ed5d"
+sourcemapped-stacktrace-node@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/sourcemapped-stacktrace-node/-/sourcemapped-stacktrace-node-2.1.5.tgz#b9513da232941ad34d22fef949f708e514ffb054"
   dependencies:
     es6-promise "^4.1.1"
     isomorphic-fetch "^2.2.1"
@@ -6750,9 +6750,9 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@3.2.x, uglify-js@^3.0.13:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.2.1.tgz#d6427fd45a25fefc5d196689c0c772a6915e10fe"
+uglify-js@3.2.x:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.2.2.tgz#870e4b34ed733d179284f9998efd3293f7fd73f6"
   dependencies:
     commander "~2.12.1"
     source-map "~0.6.1"
@@ -6765,6 +6765,13 @@ uglify-js@^2.6, uglify-js@^2.8.29:
     yargs "~3.10.0"
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
+
+uglify-js@^3.0.13:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.2.1.tgz#d6427fd45a25fefc5d196689c0c772a6915e10fe"
+  dependencies:
+    commander "~2.12.1"
+    source-map "~0.6.1"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Switch to preact-compat

```
🔥  /shell.html pageerror: Error: DOMException: Failed to execute 'createElement' on 'Document': The tag name provided ('[object Object]') is not a valid name.
    at createElement (../node_modules/preact/dist/preact.esm.js:183:0)
    at createNode (../node_modules/preact/dist/preact.esm.js:364:0)
    at idiff (../node_modules/preact/dist/preact.esm.js:306:0)
    at diff (../node_modules/preact/dist/preact.esm.js:949:0)
    at vnode (../node_modules/preact-compat/dist/preact-compat.es.js:149:0)
    at __WEBPACK_IMPORTED_MODULE_0_react__ (index.js:30:7)
    at call (../webpack/bootstrap 3d46b713f8f74ea5ecff:49:0)
    at __webpack_require__ (../static/js/main.6fe07f11.js:3020:17)
    at call (../webpack/bootstrap 3d46b713f8f74ea5ecff:49:0)
    at http://localhost:45678/static/js/main.6fe07f11.js:1:1387
```